### PR TITLE
Prior organization

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,7 +3,11 @@
 
 name: Run tests
 
-on: [push,pull_request]
+on: 
+  push:
+    branches:
+      -main
+  pull_request: {} 
 
 jobs:
   build:

--- a/pysersic/priors.py
+++ b/pysersic/priors.py
@@ -424,6 +424,10 @@ class PySersicMultiPrior(BasePrior):
             properties.set_flux_guess(catalog['flux'][ind])
             properties.set_r_eff_guess(r_eff_guess = catalog['r'][ind])
             properties.set_position_guess((catalog['x'][ind],catalog['y'][ind]) )
+            try:
+                properties.set_theta_guess(catalog['theta'][ind])
+            except:
+                pass 
 
             if catalog['type'][ind] == 'sersic':
                 prior = generate_sersic_prior(properties,suffix = f'_{ind:d}')
@@ -672,6 +676,10 @@ class SourceProperties():
         self.set_theta_guess(**kwargs)
         self.set_position_guess(**kwargs)
         return self
+    
+    def set_sky_guess(self,sky_guess=None):
+        edge_pixels = np.concatenate([self.image[:5,:]])
+
     def set_flux_guess(self,flux_guess=None,flux_guess_err = None,**kwargs):
         if flux_guess is None:
             flux_guess = self.cat.segment_flux

--- a/pysersic/priors.py
+++ b/pysersic/priors.py
@@ -657,6 +657,7 @@ class SourceProperties():
             self.cat = data_properties(self.image,mask=self.mask.astype(bool))
         else:
             self.cat = data_properties(self.image)
+        _ = self.measure_properties() 
 
     def measure_properties(self,**kwargs):
         self.set_flux_guess(**kwargs)

--- a/pysersic/priors.py
+++ b/pysersic/priors.py
@@ -661,8 +661,8 @@ class SourceProperties():
         self.set_sky_guess(**kwargs)
         return self
     
-    def set_sky_guess(self,sky_guess=None,sky_rms=None):
-        edge_pixels = np.concatenate((self.image[:5,:],self.image[-5:,:],self.image[:,:5],self.image[:,-5:]))
+    def set_sky_guess(self,sky_guess=None,sky_rms=None,n_pix_sample=5):
+        edge_pixels = np.concatenate((self.image[:n_pix_sample,:],self.image[-n_pix_sample:,:],self.image[:,:n_pix_sample],self.image[:,-n_pix_sample:]),axis=None)
         median_val = np.median(edge_pixels)
         if sky_guess is None:
             self.sky_guess = median_val

--- a/pysersic/priors.py
+++ b/pysersic/priors.py
@@ -679,6 +679,7 @@ class SourceProperties():
             self.sky_guess = median_val
         if sky_rms is None:
             self.sky_rms = np.std(edge_pixels)
+        return self
 
     def set_flux_guess(self,flux_guess=None,flux_guess_err = None,**kwargs):
         if flux_guess is None:

--- a/pysersic/priors.py
+++ b/pysersic/priors.py
@@ -656,8 +656,10 @@ class SourceProperties():
     def __init__(self,image,mask=None):
         self.image = image 
         self.mask = mask 
+        
         if self.mask is not None:
             self.cat = data_properties(self.image,mask=self.mask.astype(bool))
+            self.mask_image = np.ma.masked_array(self.image,self.mask)
         else:
             self.cat = data_properties(self.image)
         _ = self.measure_properties() 
@@ -671,7 +673,7 @@ class SourceProperties():
         return self
     
     def set_sky_guess(self,sky_guess=None,sky_rms=None,n_pix_sample=5):
-        edge_pixels = np.concatenate((self.image[:n_pix_sample,:],self.image[-n_pix_sample:,:],self.image[:,:n_pix_sample],self.image[:,-n_pix_sample:]),axis=None)
+        edge_pixels = np.concatenate((self.mask_image[:n_pix_sample,:],self.mask_image[-n_pix_sample:,:],self.mask_image[:,:n_pix_sample],self.mask_image[:,-n_pix_sample:]),axis=None)
         median_val = np.median(edge_pixels)
         if sky_guess is None:
             self.sky_guess = median_val

--- a/pysersic/priors.py
+++ b/pysersic/priors.py
@@ -461,7 +461,7 @@ class PySersicMultiPrior(BasePrior):
             all_params.append(prior_cur())
         return all_params
 
-def autoprior(image: jax.numpy.array,
+def autoprior(image_properties,
             profile_type: str,
             mask: Optional[jax.numpy.array] = None,
             sky_type: Optional[str] = 'none')-> PySersicSourcePrior:
@@ -480,21 +480,20 @@ def autoprior(image: jax.numpy.array,
     dict
         Dictionary containing numpyro Distribution objects for each parameter
     """
-    image_properties = ImageProperties(image,mask=mask)
     if profile_type == 'sersic':
-        prior_dict = generate_sersic_prior(image, sky_type = sky_type,mask=mask)
+        prior_dict = generate_sersic_prior(image_properties, sky_type = sky_type,mask=mask)
     
     elif profile_type == 'doublesersic':
-        prior_dict = generate_doublesersic_prior(image, sky_type = sky_type,mask=mask)
+        prior_dict = generate_doublesersic_prior(image_properties, sky_type = sky_type,mask=mask)
 
     elif profile_type == 'pointsource':
-        prior_dict = generate_pointsource_prior(image, sky_type = sky_type,mask=mask)
+        prior_dict = generate_pointsource_prior(image_properties, sky_type = sky_type,mask=mask)
    
     elif profile_type in 'exp':
-        prior_dict = generate_exp_prior(image, sky_type = sky_type,mask=mask)
+        prior_dict = generate_exp_prior(image_properties, sky_type = sky_type,mask=mask)
 
     elif profile_type in 'dev':
-        prior_dict = generate_dev_prior(image, sky_type = sky_type,mask=mask)
+        prior_dict = generate_dev_prior(image_properties, sky_type = sky_type,mask=mask)
     
     return prior_dict
 

--- a/pysersic/priors.py
+++ b/pysersic/priors.py
@@ -664,7 +664,7 @@ def generate_pointsource_prior(image_properties,
 
 
 
-class ImageProperties():
+class SourceProperties():
     def __init__(self,image,mask=None):
         self.image = image 
         self.mask = mask 
@@ -672,7 +672,7 @@ class ImageProperties():
             self.cat = data_properties(self.image,mask=self.mask.astype(bool))
         else:
             self.cat = data_properties(self.image)
-    
+
     def visualize(self,figsize=(6,6),cmap='gray',scale=1):
         if not hasattr(self,'flux_guess'):
             self.set_flux_guess() 
@@ -702,15 +702,12 @@ class ImageProperties():
         ax.plot(x,y,'r',lw=2)
         plt.show() 
 
-
-        
-
     def measure_properties(self,**kwargs):
         self.set_flux_guess(**kwargs)
         self.set_r_eff_guess(**kwargs)
         self.set_theta_guess(**kwargs)
         self.set_position_guess(**kwargs)
-
+        return self
     def set_flux_guess(self,flux_guess=None,flux_guess_err = None,**kwargs):
         if flux_guess is None:
             flux_guess = self.cat.segment_flux
@@ -718,20 +715,22 @@ class ImageProperties():
             flux_guess_err = flux_guess_err
         else:
             if flux_guess > 0:
-                flux_guess_err = 2*jnp.sqrt( flux_guess )
+                flux_guess_err = 2*np.sqrt( flux_guess )
             else:
-                flux_guess_err = jnp.sqrt(jnp.abs(flux_guess))
+                flux_guess_err = np.sqrt(np.abs(flux_guess))
                 flux_guess = 0.
         
         self.flux_guess = flux_guess 
         self.flux_guess_err = flux_guess_err
+        return self 
     
     def set_r_eff_guess(self,r_eff_guess=None,**kwargs):
         if r_eff_guess is None:
             r_eff_guess = self.cat.kron_radius.value
     
         self.r_eff_guess = r_eff_guess
-        self.r_scale = jnp.sqrt(r_eff_guess) 
+        self.r_scale = np.sqrt(r_eff_guess) 
+        return self
 
     def set_theta_guess(self,theta_guess=None,**kwargs):
         if theta_guess is None:
@@ -740,7 +739,7 @@ class ImageProperties():
         if np.isnan(theta_guess):
             theta_guess = 0
         self.theta_guess = theta_guess 
-    
+        return self
     def set_position_guess(self,position_guess=None,**kwargs):
         if position_guess is None:
             self.xc_guess = self.cat.centroid_win[0]
@@ -748,16 +747,14 @@ class ImageProperties():
         else:
             self.xc_guess = position_guess[0]
             self.yc_guess = position_guess[1]
-
-    def autoprior(self,
+        return self
+    def generate_prior(self,
                 profile_type: str,
                 sky_type: Optional[str] = 'none')-> PySersicSourcePrior:
         """Function to generate default priors based on a given image and profile type
 
         Parameters
         ----------
-        image : jax.numpy.array
-            Masked image
         profile_type : str
             Type of profile
         sky_type : str, default 'none'

--- a/pysersic/priors.py
+++ b/pysersic/priors.py
@@ -208,6 +208,9 @@ class PySersicSourcePrior(BasePrior):
         out += "\n" + "-"*num_dash + "\n"
         for (var, descrip) in self.repr_dict.items():
             out += var + " ---  " + descrip + "\n"    
+        out+= f'sky mode: {self.sky_type}\n'
+        out+=f'sky level: {self.sky_guess}\n'
+        out+=f'sky rms: {self.sky_rms}\n'
         return out
     
     def _build_dist_list(self)-> None:

--- a/pysersic/priors.py
+++ b/pysersic/priors.py
@@ -46,8 +46,13 @@ class BasePrior(ABC):
         self.sky_type = sky_type
         if sky_guess is None:
             self.sky_guess = 0.0 
+        else:
+            self.sky_guess = sky_guess
         if sky_rms is None:
             self.sky_rms = 1e-3
+        else:
+            self.sky_rms = sky_rms
+
         if self.sky_type not in base_sky_types:
             raise AssertionError("Sky type must be one of: ", base_sky_types)
         elif self.sky_type == 'none':
@@ -726,19 +731,19 @@ class SourceProperties():
             Dictionary containing numpyro Distribution objects for each parameter
         """
         if profile_type == 'sersic':
-            prior_dict = generate_sersic_prior(self, sky_type = sky_type,sky_guess=self.sky_guess,sky_rms=self.sky_rms)
+            prior_dict = generate_sersic_prior(self, sky_type = sky_type,)
         
         elif profile_type == 'doublesersic':
-            prior_dict = generate_doublesersic_prior(self, sky_type = sky_type,sky_guess=self.sky_guess,sky_rms=self.sky_rms)
+            prior_dict = generate_doublesersic_prior(self, sky_type = sky_type,)
 
         elif profile_type == 'pointsource':
-            prior_dict = generate_pointsource_prior(self, sky_type = sky_type,sky_guess=self.sky_guess,sky_rms=self.sky_rms)
+            prior_dict = generate_pointsource_prior(self, sky_type = sky_type,)
 
         elif profile_type in 'exp':
-            prior_dict = generate_exp_prior(self, sky_type = sky_type,sky_guess=self.sky_guess,sky_rms=self.sky_rms)
+            prior_dict = generate_exp_prior(self, sky_type = sky_type,)
 
         elif profile_type in 'dev':
-            prior_dict = generate_dev_prior(self, sky_type = sky_type,sky_guess=self.sky_guess,sky_rms=self.sky_rms)
+            prior_dict = generate_dev_prior(self, sky_type = sky_type,)
         
         return prior_dict
     

--- a/pysersic/priors.py
+++ b/pysersic/priors.py
@@ -480,6 +480,7 @@ def autoprior(image_properties,
     dict
         Dictionary containing numpyro Distribution objects for each parameter
     """
+    image_properties = ImageProperties(image,mask)
     if profile_type == 'sersic':
         prior_dict = generate_sersic_prior(image_properties, sky_type = sky_type)
     
@@ -747,3 +748,38 @@ class ImageProperties():
         else:
             self.xc_guess = position_guess[0]
             self.yc_guess = position_guess[1]
+
+    def autoprior(self,
+                profile_type: str,
+                sky_type: Optional[str] = 'none')-> PySersicSourcePrior:
+        """Function to generate default priors based on a given image and profile type
+
+        Parameters
+        ----------
+        image : jax.numpy.array
+            Masked image
+        profile_type : str
+            Type of profile
+        sky_type : str, default 'none'
+            Type of sky model to use, must be one of: 'none', 'flat', 'tilted-plane'
+        Returns
+        -------
+        dict
+            Dictionary containing numpyro Distribution objects for each parameter
+        """
+        if profile_type == 'sersic':
+            prior_dict = generate_sersic_prior(self, sky_type = sky_type)
+        
+        elif profile_type == 'doublesersic':
+            prior_dict = generate_doublesersic_prior(self, sky_type = sky_type)
+
+        elif profile_type == 'pointsource':
+            prior_dict = generate_pointsource_prior(self, sky_type = sky_type)
+
+        elif profile_type in 'exp':
+            prior_dict = generate_exp_prior(self, sky_type = sky_type)
+
+        elif profile_type in 'dev':
+            prior_dict = generate_dev_prior(self, sky_type = sky_type)
+        
+        return prior_dict


### PR DESCRIPTION
Major changes to generation of priors and auto-priors. 

Summary: 

`autoprior()` function has been depreciated and removed. 

A new class, `SourceProperties()`, ingests image (or image+mask) and estimates the guesses needed for prior generation based on the images and `astropy.data_properties()` function. One can overwrite any/all of these guesses dynamically. This class now has a `generate_prior()` method which replaces `autoprior()` which uses whatever guesses have been set/computed in order to generate a prior object. 

Additionally, sky values for the value and rms are now computed off of the image (by default using 5 pixels near the edge of the image). These, like other guesses, can be set/overwritten. 

The `__repr__` for the prior class now prints the sky values being used. 


A `.vizualize()` method in `SourceProperties` allows one to see the galaxy with views of the effective radius, center, and theta that were automatically determined. (not sure how to "show off" flux...). 