### PR TITLE
Ensure Proper types of input data

### DIFF
--- a/pysersic/pysersic.py
+++ b/pysersic/pysersic.py
@@ -63,9 +63,9 @@ class BaseFitter(ABC):
         self.data = jnp.array(data.astype(np.float64))
         self.rms = jnp.array(rms.astype(np.float64))
         self.psf = jnp.array(psf.astype(np.float64))
-        self.mask = parse_mask(mask.astype(np.int16),self.data)
+        self.mask = parse_mask(mask.astype(np.int64),self.data)
         data_isgood = check_input_data(self.data,rms=self.rms,psf=self.psf,mask=jnp.logical_not(self.mask))
-        self.renderer = renderer(data.shape, psf, **renderer_kwargs)
+        self.renderer = renderer(data.shape, self.psf, **renderer_kwargs)
     
         self.prior_dict = {}
 

--- a/pysersic/pysersic.py
+++ b/pysersic/pysersic.py
@@ -60,10 +60,10 @@ class BaseFitter(ABC):
         self.loss_func = loss_func
 
         
-        self.data = jnp.array(data.astype(np.float64))
-        self.rms = jnp.array(rms.astype(np.float64))
-        self.psf = jnp.array(psf.astype(np.float64))
-        self.mask = parse_mask(mask.astype(np.int64),self.data)
+        self.data = jnp.array(data.astype(np.float32))
+        self.rms = jnp.array(rms.astype(np.float32))
+        self.psf = jnp.array(psf.astype(np.float32))
+        self.mask = parse_mask(mask.astype(np.int16),self.data)
         data_isgood = check_input_data(self.data,rms=self.rms,psf=self.psf,mask=jnp.logical_not(self.mask))
         self.renderer = renderer(data.shape, self.psf, **renderer_kwargs)
     

--- a/pysersic/pysersic.py
+++ b/pysersic/pysersic.py
@@ -63,7 +63,7 @@ class BaseFitter(ABC):
         self.data = jnp.array(data.astype(np.float32))
         self.rms = jnp.array(rms.astype(np.float32))
         self.psf = jnp.array(psf.astype(np.float32))
-        self.mask = parse_mask(mask.astype(np.int16),self.data)
+        self.mask = parse_mask(mask,self.data)
         data_isgood = check_input_data(self.data,rms=self.rms,psf=self.psf,mask=jnp.logical_not(self.mask))
         self.renderer = renderer(data.shape, self.psf, **renderer_kwargs)
     
@@ -535,7 +535,7 @@ def parse_mask(mask:ArrayLike=None,data:ArrayLike=None):
     if mask is None:
         return jnp.ones_like(data).astype(jnp.bool_)
     else:
-        return jnp.logical_not(jnp.array(mask)).astype(jnp.bool_)
+        return jnp.logical_not(jnp.array(mask.astype(int))).astype(jnp.bool_)
 
 def check_input_data(data:ArrayLike,rms:ArrayLike,psf:ArrayLike,mask:ArrayLike=None):
     """Check input data for certain conditions and raise warnings or exceptions if needed

--- a/pysersic/pysersic.py
+++ b/pysersic/pysersic.py
@@ -60,10 +60,10 @@ class BaseFitter(ABC):
         self.loss_func = loss_func
 
         
-        self.data = jnp.array(data) 
-        self.rms = jnp.array(rms)
-        self.psf = jnp.array(psf)
-        self.mask = parse_mask(mask,self.data)
+        self.data = jnp.array(data.astype(np.float64))
+        self.rms = jnp.array(rms.astype(np.float64))
+        self.psf = jnp.array(psf.astype(np.float64))
+        self.mask = parse_mask(mask.astype(np.int16),self.data)
         data_isgood = check_input_data(self.data,rms=self.rms,psf=self.psf,mask=jnp.logical_not(self.mask))
         self.renderer = renderer(data.shape, psf, **renderer_kwargs)
     


### PR DESCRIPTION
Addressing bug in which Jax complains about input dtype. This came up in the renderer and was likely due to the actual datatype saved to file for the psf in the example, but I figured it was wise to coerce the input arrays to the proper float values needed by Jax regardless to prevent any future confusion. I've confirmed that this quick fix resolves the errors arising when trying to initialize a fitter in the current examples.