### PR TITLE
Prior and Rendering changes

### DIFF
--- a/pysersic/pysersic.py
+++ b/pysersic/pysersic.py
@@ -356,8 +356,8 @@ class FitSingle(BaseFitter):
 
             obs = out + sky
             if return_model:
-                deterministic('model', obs)
-            self.loss_func(obs, self.data, self.rms, self.mask)
+                deterministic(f'model{self.prior.suffix}', obs)
+            self.loss_func(obs, self.data, self.rms, self.mask, suffix = self.prior.suffix)
         return model
 
     
@@ -416,12 +416,10 @@ class FitMulti(BaseFitter):
             sky = self.prior.sample_sky(self.renderer.X, self.renderer.Y)
 
             obs = out + sky
-
-            if return_model:
-                obs = deterministic('model', obs)
             
-            loss = self.loss_func(obs, self.data, self.rms, self.mask)
-            return loss
+            if return_model:
+                deterministic(f'model{self.prior.suffix}', obs)
+            self.loss_func(obs, self.data, self.rms, self.mask, suffix = self.prior.suffix)
 
         return model
 

--- a/pysersic/pysersic.py
+++ b/pysersic/pysersic.py
@@ -15,7 +15,7 @@ from numpyro.handlers import condition, trace
 from numpyro.infer import SVI, Trace_ELBO
 from numpyro.infer.svi import SVIRunResult
 from pysersic.exceptions import *
-from pysersic.priors import PySersicMultiPrior, PySersicSourcePrior
+from pysersic.priors import PySersicMultiPrior, PySersicSourcePrior, base_profile_params
 from pysersic.rendering import BaseRenderer, HybridRenderer
 from pysersic.results import PySersicResults
 
@@ -102,6 +102,7 @@ class BaseFitter(ABC):
                 sampler_kwargs: Optional[dict] ={},
                 mcmc_kwargs: Optional[dict] = {},
                 return_model: Optional[bool] = True,
+                reparam_func: Optional[Callable] = lambda x: x,
                 rkey: Optional[jax.random.PRNGKey] = jax.random.PRNGKey(3)     
         ) -> pandas.DataFrame:
         """ Perform inference using a NUTS sampler
@@ -132,11 +133,12 @@ class BaseFitter(ABC):
         """
 
         model =  self.build_model(return_model = return_model)
-        self.sampler =infer.MCMC(infer.NUTS(model,init_strategy=init_strategy, **sampler_kwargs),num_chains=num_chains, num_samples=num_samples, num_warmup=num_warmup,  **mcmc_kwargs)
-        self.sampler.run(rkey)
+        model = reparam_func(model)
+        sampler =infer.MCMC(infer.NUTS(model,init_strategy=init_strategy, **sampler_kwargs),num_chains=num_chains, num_samples=num_samples, num_warmup=num_warmup,  **mcmc_kwargs)
+        sampler.run(rkey)
         self.sampling_results = PySersicResults(data=self.data,rms=self.rms,psf=self.psf,mask=self.mask,loss_func=self.loss_func,renderer=self.renderer)
         self.sampling_results.add_prior(self.prior)
-        self.sampling_results.injest_data(sampler = self.sampler)
+        self.sampling_results.injest_data(sampler = sampler)
         return self.sampling_results 
         
 
@@ -187,7 +189,7 @@ class BaseFitter(ABC):
         model_cur = self.build_model(return_model=return_model)
         guide = autoguide(model_cur)
 
-        svi_kernel = SVI(model_cur,guide, optim.Adam(0.1), loss = ELBO_loss, **SVI_kwargs)
+        svi_kernel = SVI(model_cur,guide, optim.Adam(0.01), loss = ELBO_loss, **SVI_kwargs)
         numpyro_svi_result = train_numpyro_svi_early_stop(svi_kernel,rkey=rkey,lr_init=lr_init,
                                                         num_round=num_round, **train_kwargs)
 
@@ -219,7 +221,7 @@ class BaseFitter(ABC):
         """
         model_cur = self.build_model(return_model=return_model)
         autoguide_map = infer.autoguide.AutoDelta(model_cur, init_loc_fn= infer.init_to_median)
-        train_kwargs = dict(lr_init = 0.01, num_round = 3,frac_lr_decrease  = 0.1, patience = 250, optimizer = optim.Adam, max_train = int(1e4))
+        train_kwargs = dict(lr_init = 0.1, num_round = 3,frac_lr_decrease  = 0.1, patience = 250, optimizer = optim.Adam, max_train = int(1e4))
         svi_kernel = SVI(model_cur,autoguide_map, optim.Adam(0.01),loss=Trace_ELBO())
         
         res = train_numpyro_svi_early_stop(svi_kernel,rkey=rkey, **train_kwargs)
@@ -231,12 +233,12 @@ class BaseFitter(ABC):
         trace_out = trace(condition(model_cur, use_dict)).get_trace()
         real_out = {}
         for key in trace_out:
-            if key == 'Loss':
+            if 'Loss' in key:
                 continue
             elif key == 'model':
                 real_out[key] = np.asarray(trace_out[key]['value'])
             elif not ('base' in key or 'auto' in key or 'unwrapped' in key or 'factor' in key or 'loss' in key):
-                real_out[key] = float('{:.5e}'.format(trace_out[key]['value']) )
+                real_out[key] = np.round(trace_out[key]['value'], 5 )
 
         return real_out
     
@@ -327,6 +329,7 @@ class FitSingle(BaseFitter):
 
         if prior.profile_type not in self.renderer.profile_types:
             raise AssertionError('Profile must be one of:', self.renderer.profile_types)
+        self.profile_type_number = 0
         self.prior = prior
         
 
@@ -347,7 +350,7 @@ class FitSingle(BaseFitter):
         @numpyro.handlers.reparam(config = self.prior.reparam_dict)
         def model(return_model: bool = return_model):
             params = self.prior()
-            out = self.renderer.render_source(params, self.prior.profile_type)
+            out = self.renderer.render_source(params, self.prior.profile_type, suffix = self.prior.suffix)
 
             sky = self.prior.sample_sky(self.renderer.X, self.renderer.Y)
 
@@ -409,7 +412,7 @@ class FitMulti(BaseFitter):
         def model(return_model: bool = return_model):
             source_variables = self.prior()
 
-            out = self.renderer.render_multi(self.prior.catalog['type'],source_variables)
+            out = self.renderer.render_for_model(source_variables,self.prior.catalog['type'], suffix = self.prior.suffix)
             sky = self.prior.sample_sky(self.renderer.X, self.renderer.Y)
 
             obs = out + sky
@@ -443,7 +446,7 @@ class FitMulti(BaseFitter):
         results_dict = {}
         for i in range(self.prior.N_sources):
             results_dict[f'source_{i}'] = {}
-            for pname in self.prior.all_priors[i].param_names:
+            for pname in base_profile_params[self.prior.catalog['type'][i]]:
                 results_dict[f'source_{i}'][pname] = raw_dict.pop(pname + f'_{i:d}')
         results_dict.update(raw_dict)
         return results_dict

--- a/pysersic/results.py
+++ b/pysersic/results.py
@@ -163,7 +163,7 @@ class PySersicResults():
             for var in var_names:
                 if ('base' in var) or ('auto' in var) or ('unwrapped' in var):
                     to_drop.append(var)
-                elif var == 'model':
+                elif 'model' in var:
                     to_drop.append(var)
                     if save_model:
                         self.models = data['posterior'][var]

--- a/tests/test_fitters.py
+++ b/tests/test_fitters.py
@@ -6,6 +6,7 @@ from jax.random import PRNGKey
 import arviz
 from numpyro import distributions as dist,infer,sample, optim
 from pysersic.pysersic import train_numpyro_svi_early_stop
+from pysersic.priors import estimate_sky
 
 
 
@@ -91,7 +92,12 @@ cat['type'] = ['pointsource','pointsource']
 mp = priors.PySersicMultiPrior(catalog = cat, sky_type='none')
 multi_fitter = FitMulti(im_m,rms,psf, mp)
 
-def test_FitMulti_map():
+sky_guess, sky_guess_err, n_pix_sky = estimate_sky(im_m)
+@pytest.mark.parametrize('sky_type', ['none', 'flat', 'tilted-plane'])
+def test_FitMulti_map(sky_type):
+        mp = priors.PySersicMultiPrior(catalog = cat, sky_type=sky_type,sky_guess  = sky_guess, sky_guess_err=sky_guess_err)
+        multi_fitter = FitMulti(im_m,rms,psf, mp)
+
         map_dict = multi_fitter.find_MAP(rkey = PRNGKey(10))
 
         assert map_dict['source_0']['xc'] == pytest.approx(10., rel = 1e-3)        

--- a/tests/test_fitters.py
+++ b/tests/test_fitters.py
@@ -63,7 +63,7 @@ def test_FitSingle_sample():
         post_sum = arviz.summary(res.idata)
 
         assert post_sum['mean']['flux'] == pytest.approx(199.4, rel = 5e-2)
-        assert post_sum['sd']['flux'] == pytest.approx(0.46, rel = 5e-2)
+        assert post_sum['sd']['flux'] == pytest.approx(0.45, rel = 5e-2)
 
         assert post_sum['mean']['xc'] == pytest.approx(20.02, rel = 1e-2)
         assert post_sum['sd']['xc'] == pytest.approx(0.007, rel = 2e-1)
@@ -131,7 +131,7 @@ def test_FitMulti_sample():
         assert post_sum['sd']['flux_1'] == pytest.approx(0.42, rel = 1e-1)
 
         assert post_sum['mean']['xc_0'] == pytest.approx(10.0, rel = 1e-2)
-        assert post_sum['sd']['xc_0'] == pytest.approx(0.009, rel = 1e-1)
+        assert post_sum['sd']['xc_0'] == pytest.approx(0.01, rel = 2e-1)
         assert post_sum['mean']['xc_1'] == pytest.approx(30., rel = 1e-2)
         assert post_sum['sd']['xc_1'] == pytest.approx(0.01, rel = 1e-1)
 

--- a/tests/test_fitters.py
+++ b/tests/test_fitters.py
@@ -16,7 +16,7 @@ im += rng.normal(scale = 0.05, size = (40,40))
 rms = np.ones(im.shape)*0.05
 psf = Gaussian2DKernel(x_stddev=2.5).array
 renderer = rendering.HybridRenderer((40,40), psf)
-im = im + renderer.render_pointsource(20.,20., 200.)
+im = im + renderer.render_source( dict(xc = 20.,yc=20., flux = 200.), 'pointsource' )
 
 props = priors.SourceProperties(im)
 prior = props.generate_prior(profile_type='pointsource')
@@ -35,10 +35,10 @@ def test_FitSingle_posterior(method):
         post_sum = res.summary()
 
         assert post_sum['mean']['flux'] == pytest.approx(199.4, rel = 1e-2)
-        assert post_sum['sd']['flux'] == pytest.approx(0.43, rel = 5e-2)
+        assert post_sum['sd']['flux'] == pytest.approx(0.44, rel = 1e-1)
 
         assert post_sum['mean']['xc'] == pytest.approx(20.02, rel = 1e-2)
-        assert post_sum['sd']['xc'] == pytest.approx(0.0085, rel = 1e-1)
+        assert post_sum['sd']['xc'] == pytest.approx(0.0085, rel = 2e-1)
         
         assert post_sum['mean']['yc'] == pytest.approx(19.99, rel = 1e-2)
         assert post_sum['sd']['yc'] ==  pytest.approx(0.008, rel = 1e-1)
@@ -52,7 +52,7 @@ def test_FitSingle_sample():
         assert post_sum['sd']['flux'] == pytest.approx(0.46, rel = 5e-2)
 
         assert post_sum['mean']['xc'] == pytest.approx(20.02, rel = 1e-2)
-        assert post_sum['sd']['xc'] == pytest.approx(0.0085, rel = 1e-1)
+        assert post_sum['sd']['xc'] == pytest.approx(0.007, rel = 2e-1)
         
         assert post_sum['mean']['yc'] == pytest.approx(19.99, rel = 1e-2)
         assert post_sum['sd']['yc'] ==  pytest.approx(0.0085, rel = 1e-1)
@@ -64,7 +64,8 @@ im += rng.normal(scale = 0.05, size = (40,40))
 rms = np.ones(im.shape)*0.05
 psf = Gaussian2DKernel(x_stddev=2.5).array
 renderer = rendering.HybridRenderer((40,40), psf)
-im = im + renderer.render_pointsource(10.,30., 150.)+ renderer.render_pointsource(30.,10., 150.)
+im = im + renderer.render_source( dict(xc = 10.,yc = 30., flux  = 150.), 'pointsource' )
+im = im + renderer.render_source( dict(yc = 10.,xc = 30., flux  = 150.), 'pointsource' )
 
 cat = {}
 cat['x'] = [10.,30.]
@@ -93,7 +94,7 @@ def test_FitMulti_posterior(method):
         assert post_sum['mean']['flux_0'] == pytest.approx(150.4, rel = 1e-2)
         assert post_sum['sd']['flux_0'] == pytest.approx(0.42, rel = 1e-1)
         assert post_sum['mean']['flux_1'] == pytest.approx(150., rel = 1e-2)
-        assert post_sum['sd']['flux_1'] == pytest.approx(0.45, rel = 5e-2)
+        assert post_sum['sd']['flux_1'] == pytest.approx(0.45, rel = 1e-1)
 
         assert post_sum['mean']['xc_0'] == pytest.approx(10.0, rel = 1e-2)
         assert post_sum['sd']['xc_0'] == pytest.approx(0.01, rel = 1e-1)
@@ -115,7 +116,7 @@ def test_FitMulti_sample():
         assert post_sum['sd']['flux_1'] == pytest.approx(0.42, rel = 1e-1)
 
         assert post_sum['mean']['xc_0'] == pytest.approx(10.0, rel = 1e-2)
-        assert post_sum['sd']['xc_0'] == pytest.approx(0.01, rel = 1e-1)
+        assert post_sum['sd']['xc_0'] == pytest.approx(0.009, rel = 1e-1)
         assert post_sum['mean']['xc_1'] == pytest.approx(30., rel = 1e-2)
         assert post_sum['sd']['xc_1'] == pytest.approx(0.01, rel = 1e-1)
 

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -15,8 +15,9 @@ err_tol = 0.01 # 1% error tolerence for total flux
 @pytest.mark.parametrize("pos", [(50,50),(50.5,50.5),(50.25,50.25) ,(50.,50.5),(50.5,50.)]) 
 def test_point_source(renderer,pos):
     flux = 10.
+    params = dict(flux = flux, xc = pos[0], yc = pos[1] )
     renderer_test = renderer((100,100), psf)
-    im = renderer_test.render_pointsource(pos[0],pos[1],flux)
+    im = renderer_test.render_source(params, 'pointsource')
     assert pytest.approx(im.sum(), rel = err_tol) == flux
 
 
@@ -29,6 +30,8 @@ def test_point_source(renderer,pos):
 def test_sersic(renderer,pos,re,n,ellip,theta):
     renderer_test = renderer((150,150), psf)
     flux = 10
+    params = dict(flux = flux, xc = pos[0], yc = pos[1], n = n, ellip = ellip, theta = theta, r_eff = re )
+
     #Calculate fraction of flux contained in image
     int_test = partial(render_sersic_2d, xc = pos[0],yc = pos[1], flux = 10, r_eff = re, n = n, ellip = ellip,theta = theta)
     to_int = lambda x,y: float(int_test(x,y))
@@ -36,7 +39,7 @@ def test_sersic(renderer,pos,re,n,ellip,theta):
     hi_fun = lambda x: 150. 
     flux_int,_ = dblquad(to_int, 0.,150., lo_fun,hi_fun,epsrel=5.e-3)
     
-    im = renderer_test.render_sersic(pos[0],pos[1],flux,re,n,ellip,theta)
+    im = renderer_test.render_source(params, 'sersic')
     total = float( jnp.sum(im) )
     assert pytest.approx(flux_int, rel = err_tol) == total
 
@@ -48,12 +51,13 @@ def test_sersic(renderer,pos,re,n,ellip,theta):
 @pytest.mark.parametrize("theta", [0,3.14/4.]) 
 def test_exp_dev(renderer,prof,pos,re,ellip,theta):
     flux = 10.
+    params = dict(flux = flux, xc = pos[0], yc = pos[1], ellip = ellip, theta = theta, r_eff = re )
     renderer_test = renderer((150,150), psf)
+    im = renderer_test.render_source(params, prof)
+    
     if prof == 'exp':
-        im = renderer_test.render_exp(pos[0],pos[1],flux,re,ellip,theta)
         n=1.
     if prof == 'dev':
-        im = renderer_test.render_dev(pos[0],pos[1],flux,re,ellip,theta)
         n=4.
 
     #Calculate fraction of flux contained in image
@@ -67,25 +71,3 @@ def test_exp_dev(renderer,prof,pos,re,ellip,theta):
     total = float( jnp.sum(im) )
     assert pytest.approx(flux_int, rel = err_tol) == total
 
-
-def test_sky_rendering():
-    renderer_test = BaseRenderer((100,100), psf)
-
-    assert renderer_test.render_sky(0, None) == 0
-
-    assert renderer_test.render_sky(1., 'flat') == 1
-
-    sky_1 = renderer_test.render_sky([1e-4,0.,0.], 'tilted-plane')
-    assert sky_1.shape == (100,100)
-    sky_sum_1 = float(jnp.sum(sky_1))
-    assert pytest.approx(1e-4*100*100, rel = 1e-6) == sky_sum_1
-
-    sky_2 = renderer_test.render_sky([0.,1e-3,0.], 'tilted-plane')
-    assert sky_2.shape == (100,100)
-    sky_sum_2 = float(jnp.sum(sky_2))
-    assert pytest.approx(0, abs = 1e-4) == sky_sum_2
-
-    sky_3 = renderer_test.render_sky([0.,0.,1e-3,], 'tilted-plane')
-    assert sky_3.shape == (100,100)
-    sky_sum_3 = float(jnp.sum(sky_3))
-    assert pytest.approx(0, abs = 1e-4) == sky_sum_3


### PR DESCRIPTION
These are some backend changes to the priors and renderering modules mostly. Nothing user facing but changes to make upkeep a little easier and help with the planned addition of multi-band fitting. The main changes are as follows

- Rendering
    - Parameters now passed around in dictionaries rather than as arguments to the function
    - All render_{type} functions now return 3 arrays, the Fourier transform, the intrinsic image and the convolved image. If the method currently being used doesn't use one of these it results in zeros. The BaseRenderer class now has a method called `combine_scene` which takes these three inputs to produce the final model image. This should make it easier to add extra renderers and types of source.
    - For rendering multiple sources now takes a dictionary of all the source parameters rather than being seperated

- Priors
    - Commensurate with above the sampling now the sampling functions return the parameters in a dictionary
    - Sky sampling now move to separate classes
    - Better tools for dealing with suffixes for SourcePrior and MultiPrior

- misc.
    - added suffix arguments to all of the loss functions
    - added ability to reparam model for sampling
    - Changes to the test suites to work with all of the changes