### PR TITLE
clean rms values if needed.

### DIFF
--- a/tests/test_fitters.py
+++ b/tests/test_fitters.py
@@ -51,7 +51,7 @@ def test_FitSingle_posterior(method):
         assert post_sum['sd']['xc'] == pytest.approx(0.0085, rel = 2e-1)
         
         assert post_sum['mean']['yc'] == pytest.approx(19.99, rel = 1e-2)
-        assert post_sum['sd']['yc'] ==  pytest.approx(0.008, rel = 1e-1)
+        assert post_sum['sd']['yc'] ==  pytest.approx(0.011, rel = 1e-1)
 
 
 def test_FitSingle_sample():

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -1,95 +1,132 @@
-import pytest
 import jax.numpy as jnp
 import numpy as np
-from pysersic.priors import BasePrior, PySersicMultiPrior, PySersicSourcePrior, SourceProperties, estimate_sky, NoSkyPrior,FlatSkyPrior, TiltedPlaneSkyPrior
+import pytest
 from numpyro.handlers import seed
-from numpyro import distributions as dist
- 
-prof_names = ['sersic','doublesersic','pointsource','exp','dev']
-prof_vars = [ ['xc','yc','flux','r_eff','n','ellip','theta'],
-        ['xc','yc','flux','f_1', 'r_eff_1','n_1','ellip_1', 'r_eff_2','n_2','ellip_2','theta'],
-        ['xc','yc','flux'],
-        ['xc','yc','flux','r_eff','ellip','theta'],
-        ['xc','yc','flux','r_eff','ellip','theta'],]
 
-@pytest.mark.parametrize('mask', [None, jnp.zeros((100,100))])
+from pysersic.priors import (
+    FlatSkyPrior,
+    NoSkyPrior,
+    PySersicMultiPrior,
+    PySersicSourcePrior,
+    SourceProperties,
+    TiltedPlaneSkyPrior,
+    estimate_sky,
+)
+
+prof_names = ["sersic", "doublesersic", "pointsource", "exp", "dev"]
+prof_vars = [
+    ["xc", "yc", "flux", "r_eff", "n", "ellip", "theta"],
+    [
+        "xc",
+        "yc",
+        "flux",
+        "f_1",
+        "r_eff_1",
+        "n_1",
+        "ellip_1",
+        "r_eff_2",
+        "n_2",
+        "ellip_2",
+        "theta",
+    ],
+    ["xc", "yc", "flux"],
+    ["xc", "yc", "flux", "r_eff", "ellip", "theta"],
+    ["xc", "yc", "flux", "r_eff", "ellip", "theta"],
+]
+
+
+@pytest.mark.parametrize("mask", [None, jnp.zeros((100, 100))])
 def test_SourceProperties(mask):
-    test_im = jnp.ones((100,100))
-    SP = SourceProperties(test_im, mask = mask)
+    test_im = jnp.ones((100, 100))
+    SP = SourceProperties(test_im, mask=mask)
     SP.measure_properties()
-    attributes = ['sky_guess','sky_guess_err', 'flux_guess','flux_guess_err', 'r_eff_guess','r_eff_guess_err','xc_guess','yc_guess']
+    attributes = [
+        "sky_guess",
+        "sky_guess_err",
+        "flux_guess",
+        "flux_guess_err",
+        "r_eff_guess",
+        "r_eff_guess_err",
+        "xc_guess",
+        "yc_guess",
+    ]
     for var in attributes:
         assert hasattr(SP, var)
 
-@pytest.mark.parametrize('prof, var_names', zip(prof_names,prof_vars) )
+
+@pytest.mark.parametrize("prof, var_names", zip(prof_names, prof_vars))
 def test_prior_gen(prof, var_names):
-    props = SourceProperties(jnp.ones((100,100)) )
-    prior_class = props.generate_prior(profile_type = prof)
-    assert prior_class.check_vars(verbose = True)
+    props = SourceProperties(jnp.ones((100, 100)))
+    prior_class = props.generate_prior(profile_type=prof)
+    assert prior_class.check_vars(verbose=True)
+
 
 def test_sky_sampling():
     x = jnp.arange(100)
-    X,Y = jnp.meshgrid(x,x)
+    X, Y = jnp.meshgrid(x, x)
 
-    prior_class = NoSkyPrior(sky_guess=0, sky_guess_err=1.)
+    prior_class = NoSkyPrior(sky_guess=0, sky_guess_err=1.0)
     with seed(rng_seed=1):
-        params_1 = prior_class.sample(X,Y)
+        params_1 = prior_class.sample(X, Y)
     assert params_1 == 0
 
-    prior_class = FlatSkyPrior(sky_guess = 0, sky_guess_err = 1)
+    prior_class = FlatSkyPrior(sky_guess=0, sky_guess_err=1)
     with seed(rng_seed=1):
-        params_2 = prior_class.sample(X,Y)
-    assert params_2.shape == () # Should be single value
+        params_2 = prior_class.sample(X, Y)
+    assert params_2.shape == ()  # Should be single value
 
-    prior_class = TiltedPlaneSkyPrior(sky_guess = 0, sky_guess_err = 1)
+    prior_class = TiltedPlaneSkyPrior(sky_guess=0, sky_guess_err=1)
     with seed(rng_seed=1):
-        params_3 = prior_class.sample(X,Y)
-    assert params_3.shape == (100,100) # Should be 2D array 
+        params_3 = prior_class.sample(X, Y)
+    assert params_3.shape == (100, 100)  # Should be 2D array
+
 
 def test_PySersicSourcePrior():
-    prior = PySersicSourcePrior('pointsource')
-    prior.set_gaussian_prior('xc', 10.,1.)
-    prior.set_gaussian_prior('yc', 10.,1.)
-    prior.set_uniform_prior('flux', 0, 100)
+    prior = PySersicSourcePrior("pointsource")
+    prior.set_gaussian_prior("xc", 10.0, 1.0)
+    prior.set_gaussian_prior("yc", 10.0, 1.0)
+    prior.set_uniform_prior("flux", 0, 100)
     with seed(rng_seed=1):
         params = prior()
-    assert params['xc'] == pytest.approx(8.852981, rel=1e-5)
-    assert params['yc'] == pytest.approx(8.907836, rel=1e-5)
-    assert params['flux'] == pytest.approx(37.12473, rel=1e-5)
+    assert params["xc"] == pytest.approx(9.7560796737, rel=1e-5)
+    assert params["yc"] == pytest.approx(9.7560796737, rel=1e-5)
+    assert params["flux"] == pytest.approx(37.12473, rel=1e-5)
+
 
 def test_PySersicMultiPrior():
     catalog = {}
-    catalog['x'] = [10,15,20]
-    catalog['y'] = [20,15,10]
-    catalog['flux'] = [100,100,100]
-    catalog['r'] = [5,5,5]
-    catalog['theta'] = [0,0,0]
-    catalog['type'] = ['pointsource','exp','sersic']
+    catalog["x"] = [10, 15, 20]
+    catalog["y"] = [20, 15, 10]
+    catalog["flux"] = [100, 100, 100]
+    catalog["r"] = [5, 5, 5]
+    catalog["theta"] = [0, 0, 0]
+    catalog["type"] = ["pointsource", "exp", "sersic"]
     mp = PySersicMultiPrior(catalog)
     with seed(rng_seed=1):
         params = mp()
-    
-    assert params['flux_0'] == pytest.approx(77.05961, abs = 1e-4)
-    assert params['xc_0'] == pytest.approx(8.90784, abs = 1e-4)
-    assert params['yc_0'] == pytest.approx(19.67145, abs = 1e-4)
-    assert params['flux_1'] == pytest.approx(113.12357, abs = 1e-4)
-    assert params['xc_1'] == pytest.approx(13.87507, abs = 1e-4)
-    assert params['yc_1'] == pytest.approx(16.05198, abs = 1e-4)
-    assert params['r_eff_1'] == pytest.approx(9.10913, abs = 1e-4)
-    assert params['ellip_1'] == pytest.approx(0.32804, abs = 1e-4)
-    assert params['theta_1'] == pytest.approx(6.21555, abs = 1e-4)
-    assert params['flux_2'] == pytest.approx(65.84653, abs = 1e-4)
-    assert params['xc_2'] == pytest.approx(21.38217, abs = 1e-4)
-    assert params['yc_2'] == pytest.approx(11.08138, abs = 1e-4)
-    assert params['r_eff_2'] == pytest.approx(3.35782, abs = 1e-4)
-    assert params['ellip_2'] == pytest.approx(0.78032, abs = 1e-4)
-    assert params['theta_2'] == pytest.approx(0.61594, abs = 1e-4)
-    assert params['n_2'] == pytest.approx(4.79926, abs = 1e-4)
-    
+
+    assert params["flux_0"] == pytest.approx(95.121597, abs=1e-4)
+    assert params["xc_0"] == pytest.approx(8.90784, abs=1e-4)
+    assert params["yc_0"] == pytest.approx(19.67145, abs=1e-4)
+    assert params["flux_1"] == pytest.approx(113.12357, abs=1e-4)
+    assert params["xc_1"] == pytest.approx(13.87507, abs=1e-4)
+    assert params["yc_1"] == pytest.approx(16.05198, abs=1e-4)
+    assert params["r_eff_1"] == pytest.approx(9.10913, abs=1e-4)
+    assert params["ellip_1"] == pytest.approx(0.32804, abs=1e-4)
+    assert params["theta_1"] == pytest.approx(6.21555, abs=1e-4)
+    assert params["flux_2"] == pytest.approx(65.84653, abs=1e-4)
+    assert params["xc_2"] == pytest.approx(21.38217, abs=1e-4)
+    assert params["yc_2"] == pytest.approx(11.08138, abs=1e-4)
+    assert params["r_eff_2"] == pytest.approx(3.35782, abs=1e-4)
+    assert params["ellip_2"] == pytest.approx(0.78032, abs=1e-4)
+    assert params["theta_2"] == pytest.approx(0.61594, abs=1e-4)
+    assert params["n_2"] == pytest.approx(4.79926, abs=1e-4)
+
+
 def test_sky_estimate():
     rng = np.random.default_rng(1234567)
-    test_im = rng.normal(size = (100,100))
-    med,std,npix = estimate_sky(test_im, n_pix_sample= 5)
-    assert med == pytest.approx(0., abs = 1e-2)
-    assert std == pytest.approx(1., abs = 1e-2)
+    test_im = rng.normal(size=(100, 100))
+    med, std, npix = estimate_sky(test_im, n_pix_sample=5)
+    assert med == pytest.approx(0.0, abs=1e-2)
+    assert std == pytest.approx(1.0, abs=1e-2)
     assert npix == 1900


### PR DESCRIPTION
As described in #68 and #58 some users were seeing issues with bad values in rms images even if the supplied mask correctly masked them. 

The reason is that when using mask handlers in numpyro, 
```
nu = 5.0
    with handlers.mask(mask=mask):
        loss = sample(
            f"Loss{suffix}",
            dist.StudentT(nu, mod, jnp.sqrt((nu - 2.0) / 2.0) * rms),
            obs=data,
        )
    return loss
```
the mask handling applies to the *output loss*; that is, pixels that are masked do not contribute to the loss. However, the `rms` array used to construct the loss is not affected by the maskhandler, and it assumes all values in rms to be valid. 

As a result, bad rms pixels cause the code to crash even if the provided mask covers those pixels. 

I have made the following adjustments to the `BaseFitter` init, adding a new `clean_rms` method which finds all inappropriate values in a passed rms array and sets them to some real numbers, then adds those pixels to the mask such that they are not used in calculating losses. 
``` 
        ....
        self.data = jnp.array(data.astype(np.float32))
        self.rms = jnp.array(rms.astype(np.float32))
        self.mask = parse_mask(mask, self.data)
        self.rms, self.mask = self.clean_rms_array(self.rms, self.mask)
        self.psf = jnp.array(psf.astype(np.float32))
        data_isgood = check_input_data(
            self.data, rms=self.rms, psf=self.psf, mask=jnp.logical_not(self.mask)
        )
        self.renderer = renderer(data.shape, self.psf, **renderer_kwargs)
        self.prior = None
        self.prior_dict = {}

    def clean_rms_array(self, rms, mask):
        bad_pixels = jnp.isnan(rms) | jnp.isinf(rms) | (rms <= 0)

        rms_clean = jnp.nan_to_num(rms, nan=1e3, posinf=1e3, neginf=1e3)
        rms_clean = jnp.where(rms_clean <= 0, 1e-3, rms_clean)
        updated_mask = mask & (~bad_pixels)

        return rms_clean, updated_mask
```

The fix passes the parsed mask and rms array, and updates the mask and values. Additionally, the `check_input_data` now adds a warning if the code has found bad pixels in rms, and notes they will be masked (whether they're in the user-supplied mask or not). 

