### PR TITLE
new bn approximation and description

### DIFF
--- a/docs/source/rendering.rst
+++ b/docs/source/rendering.rst
@@ -17,6 +17,8 @@ There are two optional arguments:
 
 * ``num_os`` - Number of sub-pixels in each direction to oversample by.
 
+Note that ``Pysersic`` uses an approximation to the effective radius normalizing term :math:`b_n` which is valid for all values of n between 0.1 and 10, unlike standard approximations which diverge below :math:`n<0.5` or so. 
+
 ``FourierRenderer`` and ``HybridRenderer``
 -------------------------------------------
 
@@ -37,3 +39,6 @@ Both ``FourierRenderer`` and ``HybridRenderer`` use this Gaussian decomposition 
 ``FourierRenderer``, as the name implies, renders sources solely in Fourier space. However this can lead to some artifacts, specifically, aliasing if the source is near the edge. This is because the inverse FFT assumes the image is periodic so part of the source that should lie outside the image appears opposite. To help combat this we also implement a version of the hybrid real-Fourier algorithm described in `Lang (2020) <https://arxiv.org/abs/2012.15797>`_ in ``HybridRenderer``. The innovation is to render some of the largest Gaussian components in real space to help avoid the aliasing while maintaining the benefits of rendering in Fourier space. This has one additional argument beyond those described above:
 
 * ``num_pixel_render`` - Number of Gaussian components to render in real space, beginning with the largest and counting backwards.
+
+
+As a note, due to the nature of the Fourier/Hybrid methods, they do not support sampling to Sérsic indices below 0.65, and setting a lower prior will not change the results. If you have sources that require lower than 0.65 for the index, use the ``PixelRenderer``, as it can safely render down to n of 0.1. 


### PR DESCRIPTION
This update provides a new approximation to the normalizing constant `b_n` in the Sersic Equation, currently used by our PixelRenderer (also the 1D version, in the Fourier renderer). 

The prior equation being used was `b_n = 1.9992n - 0.3721`, which is inaccurate for n below 1 (increasingly so). The new equation is 
```
bn = (2 * n - 1 / 3 + 4 / (405 * n) + 46 / (25515 * n**2)) + (
        ((0.00018073182821237496 / (n + jnp.exp(n))) + 3.7026973571904255e-5)
        / (-0.09149183119702775 - n) ** 2
    ) * (
        (
            jnp.log(n)
            + (
                ((n * 2.6248718397705195) + -0.9727511612512357)
                / (n ** (-4) + 94.78011643586419)
            )
        )
        / (n + -0.006044236674273689)
    )
```

Of which the first four terms are the popular Ciotti (1999) expansion, and the additional terms are a symbolic regression run with `pysr` which fits the residual between Ciotti and truth down to very low n. This new equation has been speed benchmarked and is equally fast (being all simple mathematical expressions), and thus "for free" ensures that with the PixelRenderer, sersic index can be safely sampled down to lower n than we expect for real galaxies without blowing up. 

Note that this new formula is also implemented in the Sersic1D method used by the Fourier/Hybrid renderer, which improves its accuracy in its lowest n regime, but other aspects of those renderers limit the lowest n to 0.65 at the moment. Whether they can be brought lower can be investigated, but might not be possible. 

Updates to the rendering description in the docs describes the change as well, and a small writeup exists which for now is available upon request. Note that most changes below are simply formatting; the real changes are just the bn lines in the two sersic formulas.